### PR TITLE
change `File` -> `LazyFile` in README.md

### DIFF
--- a/packages/lazy-file/README.md
+++ b/packages/lazy-file/README.md
@@ -25,7 +25,7 @@ A `LazyFile` improves this model by accepting an additional content type in its 
 let lazyContent: LazyContent = {
   /* See below for usage */
 };
-let file = new File(lazyContent, 'hello.txt', { type: 'text/plain' });
+let file = new LazyFile(lazyContent, 'hello.txt', { type: 'text/plain' });
 ```
 
 All other `File` functionality works as you'd expect.


### PR DESCRIPTION
I was reading the docs for `@mjackson/lazy-file` and noticed a potential typo.  Feel free to ignore / close this out. Thanks for all the work that you do!