### PR TITLE
Allow returning strings from the upload handler

### DIFF
--- a/packages/form-data-parser/src/lib/form-data.spec.ts
+++ b/packages/form-data-parser/src/lib/form-data.spec.ts
@@ -99,4 +99,27 @@ describe('parseFormData', () => {
 
     assert.equal(formData.get('file'), null);
   });
+
+  it('allows returning strings from the upload handler', async () => {
+    let request = new Request('http://localhost:8080', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW',
+      },
+      body: [
+        '------WebKitFormBoundary7MA4YWxkTrZu0gW',
+        'Content-Disposition: form-data; name="file"; filename="example.txt"',
+        'Content-Type: text/plain',
+        '',
+        'This is an example file.',
+        '------WebKitFormBoundary7MA4YWxkTrZu0gW--',
+      ].join('\r\n'),
+    });
+
+    let formData = await parseFormData(request, (fileUpload) => {
+      return fileUpload.text();
+    });
+
+    assert.equal(formData.get('file'), 'This is an example file.');
+  });
 });

--- a/packages/form-data-parser/src/lib/form-data.ts
+++ b/packages/form-data-parser/src/lib/form-data.ts
@@ -66,7 +66,7 @@ export class FileUpload implements File {
  * A function used for handling file uploads.
  */
 export interface FileUploadHandler {
-  (file: FileUpload): void | null | File | Promise<void | null | File>;
+  (file: FileUpload): void | null | string | File | Promise<void | null | string | File>;
 }
 
 async function defaultFileUploadHandler(file: FileUpload): Promise<File> {


### PR DESCRIPTION
Extends the return type of the file upload handler to return strings, as described in #16.