### PR TITLE
Add TempFileStorage

### DIFF
--- a/packages/file-storage/src/lib/temp-file-storage.spec.ts
+++ b/packages/file-storage/src/lib/temp-file-storage.spec.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { describe, it } from 'node:test';
+import { TempFileStorage } from './temp-file-storage.js';
+
+describe('TempFileStorage', () => {
+  it('stores and retrieves files', async () => {
+    await using storage = new TempFileStorage('test-');
+    let lastModified = Date.now();
+    let file = new File(['Hello, world!'], 'hello.txt', {
+      type: 'text/plain',
+      lastModified,
+    });
+
+    await storage.set('hello', file);
+
+    assert.ok(storage.has('hello'));
+
+    let retrieved = storage.get('hello');
+
+    assert.ok(retrieved);
+    assert.equal(retrieved.name, 'hello.txt');
+    assert.equal(retrieved.type, 'text/plain');
+    assert.equal(retrieved.lastModified, lastModified);
+    assert.equal(retrieved.size, 13);
+
+    let text = await retrieved.text();
+
+    assert.equal(text, 'Hello, world!');
+
+    await storage.remove('hello');
+
+    assert.ok(!storage.has('hello'));
+    assert.equal(storage.get('hello'), null);
+  });
+
+  it('only creates dir after set is called and removes the dir on disposal', async () => {
+    let dir: string;
+    {
+      await using storage = new TempFileStorage('test-');
+      assert.equal(storage.dirname, undefined);
+
+      await storage.set(
+        'hello',
+        new File(['Hello, world!'], 'hello.txt', {
+          type: 'text/plain',
+          lastModified: Date.now(),
+        }),
+      );
+
+      assert.notEqual(storage.dirname, undefined);
+      assert.doesNotThrow(() => fs.accessSync(storage.dirname!));
+      dir = storage.dirname!;
+    }
+    assert.throws(() => fs.accessSync(dir));
+  });
+});

--- a/packages/file-storage/src/lib/temp-file-storage.ts
+++ b/packages/file-storage/src/lib/temp-file-storage.ts
@@ -12,23 +12,38 @@ type MkdtempOptions = Parameters<typeof fsp.mkdtemp>[1];
  * A lazy `FileStorage` that is backed by a temporary directory on the local
  * filesystem. The temporary directory is only created if `set` is called.
  *
- * This class implements AsyncDisposable and should be used with `await using`,
- * but the `destroy` method is exposed for manual cleanup.
+ * This class provides a few methods to clean up the temporary directory:
+ *   1. This class implements `AsyncDisposable` and can be used with
+ *      `async using` if your environment/bundler supports it
+ *   2. `use` wraps a callback in a try/finally block that will execute the
+ *       cleanup function automatically
+ *   3. `destroy` allows for manual cleanup
  *
- * Note: Keys have no correlation to file names on disk, so they may be any string including
- * characters that are not valid in file names. Additionally, individual `File` names have no
- * correlation to names of files on disk, so multiple files with the same name may be stored in the
- * same storage object.
+ * Note: Keys have no correlation to file names on disk, so they may be any
+ * string including characters that are not valid in file names. Additionally,
+ * individual `File` names have no correlation to names of files on disk, so
+ * multiple files with the same name may be stored in the same storage object.
  */
 export class TempFileStorage implements FileStorage, AsyncDisposable {
   #mkdir: () => Promise<string>;
   #dirname: string | undefined;
   #metadata = new Map<string, FileMetadata>();
 
+  /**
+   * Constructs a new `TempFileStorage`. This will not create the temporary
+   * directory.
+   *
+   * @param prefix The prefix for the temporary directory
+   * @param options Options passed to `fs.mkdtemp`
+   */
   constructor(prefix: string, options?: MkdtempOptions) {
     this.#mkdir = () => fsp.mkdtemp(path.join(os.tmpdir(), prefix), options);
   }
 
+  /**
+   * The path to the directory if it has been initialized, otherwise it will be
+   * undefined
+   */
   get dirname() {
     return this.#dirname;
   }
@@ -37,6 +52,11 @@ export class TempFileStorage implements FileStorage, AsyncDisposable {
     return this.#metadata.has(key);
   }
 
+  /**
+   * Puts a file in storage at the given key.
+   *
+   * Note: This will initialize the temporary directory on the first call
+   */
   async set(key: string, file: File): Promise<void> {
     if (!this.#dirname) {
       this.#dirname = await this.#mkdir();
@@ -86,8 +106,15 @@ export class TempFileStorage implements FileStorage, AsyncDisposable {
   }
 
   /**
-   * Deletes the temporary directory and resets the metadata. Prefer using this
-   * class as a disposable with `await using` instead of calling this method.
+   * Deletes the temporary directory and resets the metadata.
+   *
+   * @example
+   * const storage = new TempFileStorage("prefix-");
+   *
+   * // Do work with the storage
+   *
+   * // Manually clean up the directory
+   * await storage.destroy();
    */
   async destroy(): Promise<void> {
     if (this.#dirname) {
@@ -97,7 +124,37 @@ export class TempFileStorage implements FileStorage, AsyncDisposable {
     }
   }
 
+  /**
+   * Automatically cleans up the temporary directory when used with `await using`
+   *
+   * @example
+   * {
+   *   await using storage = new TempFileStorage("prefix-")
+   *
+   *   // Do work with the storage
+   * }
+   * // The directory will be automatically cleaned up when the scope is left
+   */
   async [Symbol.asyncDispose](): Promise<void> {
     await this.destroy();
+  }
+
+  /**
+   * Calls a function and cleans up the directory after it finishes or errors
+   *
+   * @param f Function to be called with the storage
+   * @returns The returned value from `f`
+   *
+   * @example
+   * new TempFileStorage("prefix-").use(async (storage) => {
+   *   // Do work with the storage
+   * });
+   */
+  async use<T>(f: (storage: TempFileStorage) => T | Promise<T>): Promise<T> {
+    try {
+      return await f(this);
+    } finally {
+      await this.destroy();
+    }
   }
 }

--- a/packages/file-storage/src/lib/temp-file-storage.ts
+++ b/packages/file-storage/src/lib/temp-file-storage.ts
@@ -1,0 +1,103 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { FileStorage } from './file-storage.js';
+import { FileMetadata, isNoEntityError, storeFile } from './utils.js';
+import { openFile } from '@mjackson/lazy-file/fs';
+
+type MkdtempOptions = Parameters<typeof fsp.mkdtemp>[1];
+
+/**
+ * A lazy `FileStorage` that is backed by a temporary directory on the local
+ * filesystem. The temporary directory is only created if `set` is called.
+ *
+ * This class implements AsyncDisposable and should be used with `await using`,
+ * but the `destroy` method is exposed for manual cleanup.
+ *
+ * Note: Keys have no correlation to file names on disk, so they may be any string including
+ * characters that are not valid in file names. Additionally, individual `File` names have no
+ * correlation to names of files on disk, so multiple files with the same name may be stored in the
+ * same storage object.
+ */
+export class TempFileStorage implements FileStorage, AsyncDisposable {
+  #mkdir: () => Promise<string>;
+  #dirname: string | undefined;
+  #metadata = new Map<string, FileMetadata>();
+
+  constructor(prefix: string, options?: MkdtempOptions) {
+    this.#mkdir = () => fsp.mkdtemp(path.join(os.tmpdir(), prefix), options);
+  }
+
+  get dirname() {
+    return this.#dirname;
+  }
+
+  has(key: string): boolean {
+    return this.#metadata.has(key);
+  }
+
+  async set(key: string, file: File): Promise<void> {
+    if (!this.#dirname) {
+      this.#dirname = await this.#mkdir();
+    }
+
+    // Remove any existing file with the same key.
+    await this.remove(key);
+
+    let storedFile = await storeFile(this.#dirname, file);
+
+    this.#metadata.set(key, {
+      file: storedFile,
+      name: file.name,
+      type: file.type,
+      mtime: file.lastModified,
+    });
+  }
+
+  get(key: string): File | null {
+    let metadata = this.#metadata.get(key);
+    if (metadata == null || !this.#dirname) return null;
+
+    let filename = path.join(this.#dirname, metadata.file);
+
+    return openFile(filename, {
+      name: metadata.name,
+      type: metadata.type,
+      lastModified: metadata.mtime,
+    });
+  }
+
+  async remove(key: string): Promise<void> {
+    let metadata = this.#metadata.get(key);
+    if (metadata == null || !this.#dirname) return;
+
+    let filename = path.join(this.#dirname, metadata.file);
+
+    try {
+      await fsp.unlink(filename);
+    } catch (error) {
+      if (!isNoEntityError(error)) {
+        throw error;
+      }
+    }
+
+    this.#metadata.delete(key);
+  }
+
+  /**
+   * Deletes the temporary directory and resets the metadata. Prefer using this
+   * class as a disposable with `await using` instead of calling this method.
+   */
+  async destroy(): Promise<void> {
+    if (this.#dirname) {
+      await fsp.rm(this.#dirname, { recursive: true, force: true });
+      this.#dirname = undefined;
+      this.#metadata = new Map();
+    }
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.destroy();
+  }
+}

--- a/packages/file-storage/src/lib/utils.ts
+++ b/packages/file-storage/src/lib/utils.ts
@@ -1,0 +1,39 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+import { writeFile } from '@mjackson/lazy-file/fs';
+
+export interface FileMetadata {
+  file: string;
+  name: string;
+  type: string;
+  mtime: number;
+}
+
+function randomFilename(): string {
+  return `${new Date().getTime().toString(36)}.${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export async function storeFile(dirname: string, file: File): Promise<string> {
+  let filename = randomFilename();
+
+  let handle: fsp.FileHandle;
+  try {
+    handle = await fsp.open(path.join(dirname, filename), 'w');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      // Try again with a different filename
+      return storeFile(dirname, file);
+    } else {
+      throw error;
+    }
+  }
+
+  await writeFile(handle, file);
+
+  return filename;
+}
+
+export function isNoEntityError(obj: unknown): obj is NodeJS.ErrnoException & { code: 'ENOENT' } {
+  return obj instanceof Error && 'code' in obj && (obj as NodeJS.ErrnoException).code === 'ENOENT';
+}

--- a/packages/file-storage/src/temp.ts
+++ b/packages/file-storage/src/temp.ts
@@ -1,0 +1,1 @@
+export { TempFileStorage } from './lib/temp-file-storage.js';


### PR DESCRIPTION
I realized while implementing `form-data-parser` in a project that `LocalFileStorage` is a bad fit for apps that process uploads before persisting them elsewhere. I wanted something that wrote to a temporary directory that was removed at the end of the request handler and was only initialized if the form data contained a file. So I wrote `TempFileStorage` and wanted to contribute it back for others to use 😄 

The biggest uncertainty I have about this change is the support for `AsyncDisposable` in the general node ecosystem.