### PR TITLE
Add main fields to package.json

### DIFF
--- a/packages/fetch-proxy/package.json
+++ b/packages/fetch-proxy/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "type": "module",
+  "main": "dist/fetch-proxy.js",
   "exports": {
     ".": "./dist/fetch-proxy.js",
     "./package.json": "./package.json"

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "type": "module",
+  "main": "dist/file-storage.js",
   "exports": {
     ".": "./dist/file-storage.js",
     "./local": "./dist/local.js",

--- a/packages/form-data-parser/package.json
+++ b/packages/form-data-parser/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "type": "module",
+  "main": "dist/form-data-parser.js",
   "exports": {
     ".": "./dist/form-data-parser.js",
     "./package.json": "./package.json"

--- a/packages/headers/package.json
+++ b/packages/headers/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "type": "module",
+  "main": "dist/headers.js",
   "exports": {
     ".": "./dist/headers.js",
     "./package.json": "./package.json"

--- a/packages/lazy-file/package.json
+++ b/packages/lazy-file/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "type": "module",
+  "main": "dist/lazy-file.js",
   "exports": {
     ".": "./dist/lazy-file.js",
     "./fs": "./dist/fs.js",

--- a/packages/multipart-parser/package.json
+++ b/packages/multipart-parser/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "type": "module",
+  "main": "dist/multipart-parser.js",
   "exports": {
     ".": "./dist/multipart-parser.js",
     "./node": "./dist/multipart-parser.node.js",

--- a/packages/node-fetch-server/package.json
+++ b/packages/node-fetch-server/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "type": "module",
+  "main": "dist/node-fetch-server.js",
   "exports": {
     ".": "./dist/node-fetch-server.js",
     "./package.json": "./package.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,16 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
 
+  packages/fetch-proxy:
+    dependencies:
+      '@mjackson/headers':
+        specifier: workspace:^
+        version: link:../headers
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.16.1
+
   packages/file-storage:
     dependencies:
       '@mjackson/lazy-file':
@@ -168,16 +178,15 @@ importers:
 
   scripts:
     dependencies:
+      '@types/node':
+        specifier: ^22.5.4
+        version: 22.5.4
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
       semver:
         specifier: ^7.6.3
         version: 7.6.3
-    devDependencies:
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
 
 packages:
 
@@ -1446,7 +1455,7 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
 
   '@types/bun@1.1.8':
     dependencies:
@@ -1454,15 +1463,15 @@ snapshots:
 
   '@types/busboy@1.5.4':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
 
   '@types/express-serve-static-core@4.19.5':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -1480,7 +1489,7 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
 
   '@types/node@20.12.14':
     dependencies:
@@ -1507,19 +1516,19 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
       '@types/send': 0.17.4
 
   '@types/tmp@0.2.6': {}
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 22.5.0
+      '@types/node': 22.5.4
 
   accepts@1.3.8:
     dependencies:


### PR DESCRIPTION
## Description

I've been using the `@mjackson/headers` package in an older project that still uses the old `Node` module resolution in our `tsconfig.json`. Because of this, TypeScript will throw an error, indicating that the types are incompatible with the package.

This can also be checked by running the following command:

```bash
npx --yes @arethetypeswrong/cli --from-npm @mjackson/headers
```

Which will show the following output:

```
┌───────────────────┬──────────────────────────────┬──────────────────────────────────┐
│                   │ "@mjackson/headers"          │ "@mjackson/headers/package.json" │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ node10            │ 💀 Resolution failed         │ 🟢 (JSON)                        │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ node16 (from CJS) │ ⚠️ ESM (dynamic import only)  │ 🟢 (JSON)                        │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)                     │ 🟢 (JSON)                        │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ bundler           │ 🟢                           │ 🟢 (JSON)                        │
└───────────────────┴──────────────────────────────┴──────────────────────────────────┘
```

Add the `main` field to the `package.json` for each package and the `node10` resolution will succeed:

```
┌───────────────────┬──────────────────────────────┬──────────────────────────────────┐
│                   │ "@mjackson/headers"          │ "@mjackson/headers/package.json" │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ node10            │ 🟢                           │ 🟢 (JSON)                        │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ node16 (from CJS) │ ⚠️ ESM (dynamic import only)  │ 🟢 (JSON)                        │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)                     │ 🟢 (JSON)                        │
├───────────────────┼──────────────────────────────┼──────────────────────────────────┤
│ bundler           │ 🟢                           │ 🟢 (JSON)                        │
└───────────────────┴──────────────────────────────┴──────────────────────────────────┘
```

I also found out that the lockfile changed when running `pnpm install`. I've added these changes as well.

## How to test

- [ ] Checkout this pull request
- [ ] Run `npx --yes @arethetypeswrong/cli --pack .` for each project
- [ ] See that at least the resolution for the main `index.js` succeeds