### PR TITLE
feat: use object instead of array for sending headers

### DIFF
--- a/packages/node-fetch-server/CHANGELOG.md
+++ b/packages/node-fetch-server/CHANGELOG.md
@@ -5,6 +5,7 @@ This is the changelog for [`node-fetch-server`](https://github.com/mjackson/remi
 ## HEAD
 
 - Expose `createHeaders(req: http.IncomingMessage): Headers` API for creating headers from the headers of incoming request objects.
+- Update `sendResponse` to use an object to add support for libraries such as express while maintaining `node:http` and `node:https` compatibility.
 
 ## v0.4.1 (2024-12-04)
 

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -169,14 +169,10 @@ describe('createRequestListener', () => {
       });
 
       mock.method(res, 'end', () => {
-        assert.deepEqual(headers, [
-          'content-type',
-          'text/plain',
-          'set-cookie',
-          'a=1',
-          'set-cookie',
-          'b=2',
-        ]);
+        assert.deepEqual(headers, {
+          'content-type': 'text/plain',
+          'set-cookie': ['a=1', 'b=2'],
+        });
         resolve();
       });
 

--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -188,9 +188,17 @@ export async function sendResponse(res: http.ServerResponse, response: Response)
   // Use the rawHeaders API and iterate over response.headers so we are sure to send multiple
   // Set-Cookie headers correctly. These would incorrectly be merged into a single header if we
   // tried to use `Object.fromEntries(response.headers.entries())`.
-  let rawHeaders: string[] = [];
+  let rawHeaders: Record<string, string | string[]> = {};
   for (let [key, value] of response.headers) {
-    rawHeaders.push(key, value);
+    if (key in rawHeaders) {
+      if (Array.isArray(rawHeaders[key])) {
+        rawHeaders[key].push(value);
+      } else {
+        rawHeaders[key] = [rawHeaders[key] as string, value];
+      }
+    } else {
+      rawHeaders[key] = value;
+    }
   }
 
   res.writeHead(response.status, rawHeaders);


### PR DESCRIPTION
Update `sendResponse` to use an object to add support for libraries such as express while maintaining `node:http` and `node:https` compatibility.