### PR TITLE
local-file-storage: scalability + race fixes

### DIFF
--- a/packages/file-storage/CHANGELOG.md
+++ b/packages/file-storage/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is the changelog for [`file-storage`](https://github.com/mjackson/remix-the-web/tree/main/packages/file-storage). It follows [semantic versioning](https://semver.org/).
 
+## v0.3.1
+
+- Fixes race conditions with concurrent calls to `set`
+- Shards storage directories for more scalable file systems
+
 ## v0.3.0 (2024-11-14)
 
 - Added CommonJS build

--- a/packages/file-storage/CHANGELOG.md
+++ b/packages/file-storage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is the changelog for [`file-storage`](https://github.com/mjackson/remix-the-web/tree/main/packages/file-storage). It follows [semantic versioning](https://semver.org/).
 
-## v0.3.1
+## HEAD
 
 - Fixes race conditions with concurrent calls to `set`
 - Shards storage directories for more scalable file systems

--- a/packages/file-storage/src/lib/local-file-storage.test.ts
+++ b/packages/file-storage/src/lib/local-file-storage.test.ts
@@ -43,4 +43,31 @@ describe('LocalFileStorage', () => {
     assert.ok(!(await storage.has('hello')));
     assert.equal(await storage.get('hello'), null);
   });
+
+  it('handles race conditions', async () => {
+    let storage = new LocalFileStorage(directory);
+    let lastModified = Date.now();
+
+    let file1 = new File(['Hello, world!'], 'hello1.txt', {
+      type: 'text/plain',
+      lastModified,
+    });
+
+    let file2 = new File(['Hello, universe!'], 'hello2.txt', {
+      type: 'text/plain',
+      lastModified,
+    });
+
+    let setPromise = storage.set('one', file1);
+    await storage.set('two', file2);
+
+    let retrieved1 = await storage.get('one');
+    assert.ok(retrieved1);
+    assert.equal(await retrieved1.text(), 'Hello, world!');
+
+    await setPromise;
+    let retrieved2 = await storage.get('two');
+    assert.ok(retrieved2);
+    assert.equal(await retrieved2.text(), 'Hello, universe!');
+  });
 });

--- a/packages/file-storage/src/lib/local-file-storage.ts
+++ b/packages/file-storage/src/lib/local-file-storage.ts
@@ -104,7 +104,7 @@ export class LocalFileStorage implements FileStorage {
     let hash = crypto.createHash('sha256').update(key).digest('hex');
     let shardDir = hash.slice(0, 8);
     let directory = path.join(this.#dirname, shardDir);
-    let filename = `${hash}.bin`;
+    let filename = `${hash.slice(8)}.bin`;
     let metaname = `${hash}.meta.json`;
 
     return {


### PR DESCRIPTION
This commit fixes race conditions and potential performance issues

## Race conditions:

- Multiple calls to `set` caused race conditions with the central metafile index.
- Not only did this cause the set to fail, but it often corrupted the metafile causing a permanent, unrecoverable error since the metafile could no longer be parsed.

## Scalability:

- The single metadata file would eventually grow large in a successful application and become both a memory issue and performance bottleneck
- Additionally, storing all files in a single directory would eventually slow down the file system’s access of files in the directory.

## Changes:

- Removes race conditions with atomic reads/writes
  - Removes the metafile and instead relies on SHA-256 hashes for file keys
  - Stores metadata alongside each file as .meta.json instead of central index
  - removes filename collision handling since it’s unnecessary with hash-based names
- Performance
  - Shards files into subdirectories using first 8 chars of SHA-256 hash to maintain file system performance
  - Without a metafile, it is no longer a memory or performance bottleneck

Should rebase/squash the commits before merging, added the failing test first to prove the bug.