### PR TITLE
add function forms of the host and protocol options

### DIFF
--- a/packages/node-fetch-server/README.md
+++ b/packages/node-fetch-server/README.md
@@ -53,10 +53,42 @@ function handler(request: Request) {
   return new Response('Hello, world!');
 }
 
-let server = http.createServer(createRequestListener(handler, { host: process.env.HOST }));
+let server = http.createServer(
+  createRequestListener(handler, {
+    host: process.env.HOST,
+  }),
+);
 
 server.listen(3000);
 ```
+
+Alternatively the host and protocol can be derived from the request headers using the function forms of the `host` and `protocol` options (useful when running your server behind a reverse proxy). If the function provided returns
+a falsy value, the default behavior is used as a fallback.
+
+```ts
+import * as assert from 'node:assert/strict';
+import * as http from 'node:http';
+import { createRequestListener } from '@mjackson/node-fetch-server';
+
+function handler(request: Request) {
+  // This is now true
+  assert.equal(
+    new URL(request.url).host,
+    request.headers.get('x-forwarded-host'),
+  );
+  return new Response('Hello, world!');
+}
+
+let server = http.createServer(
+  createRequestListener(handler, {
+    host: (headers) => headers.get('x-forwarded-host'),
+    protocol: (headers) => (headers.get('x-forwarded-proto') ?? 'http') + ':',
+  }),
+);
+
+server.listen(3000);
+```
+
 
 Information about the remote client IP and port is passed as the 2nd argument to your `FetchHandler`:
 

--- a/packages/node-fetch-server/src/lib/request-listener.test.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.test.ts
@@ -129,6 +129,26 @@ describe('createRequestListener', () => {
     });
   });
 
+  it('uses the `host` option function to override the `Host` header', async () => {
+    await new Promise<void>((resolve) => {
+      let handler: FetchHandler = async (request) => {
+        assert.equal(request.url, 'http://remix.run/');
+        return new Response('Hello, world!');
+      };
+
+      let listener = createRequestListener(handler, {
+        host: (headers) => headers.get('x-forwarded-host')!,
+      });
+      assert.ok(listener);
+
+      let req = createMockRequest({ headers: { 'x-forwarded-host': 'remix.run' } });
+      let res = createMockResponse({ req });
+
+      listener(req, res);
+      resolve();
+    });
+  });
+
   it('uses the `protocol` option to construct the URL', async () => {
     await new Promise<void>((resolve) => {
       let handler: FetchHandler = async (request) => {
@@ -140,6 +160,28 @@ describe('createRequestListener', () => {
       assert.ok(listener);
 
       let req = createMockRequest({ headers: { host: 'example.com' } });
+      let res = createMockResponse({ req });
+
+      listener(req, res);
+      resolve();
+    });
+  });
+
+  it('uses the `protocol` option function to construct the URL', async () => {
+    await new Promise<void>((resolve, reject) => {
+      let handler: FetchHandler = async (request) => {
+        assert.equal(request.url, 'https://example.com/');
+        return new Response('Hello, world!');
+      };
+
+      let listener = createRequestListener(handler, {
+        protocol: (headers) => headers.get('x-forwarded-proto')! + ':',
+      });
+      assert.ok(listener);
+
+      let req = createMockRequest({
+        headers: { host: 'example.com', 'x-forwarded-proto': 'https' },
+      });
       let res = createMockResponse({ req });
 
       listener(req, res);


### PR DESCRIPTION
👋 Not sure if this is something you'd find useful, but IMO limiting the construction of `request.url` to only derive from either the `Host` header or a static `host` option (and similarly for `protocol`) is a bit too restrictive for reverse proxy setups.

Granted, you could easily just do the work directly on `request.url` that's passed to the handler, but I think being able to specify functions for those options would be the least friction option for servers running behind something like HAProxy or Nginx for HTTPS termination (we actually have multiple reverse proxies in play, so the `Host` header that comes along isn't necessarily the one that was sent by the user's browser).

From the additions to `README.md`:

> Alternatively the host and protocol can be derived from the request headers using the function forms of the `host` and `protocol` options (useful when running your server behind a reverse proxy). If the function provided returns
> a falsy value, the default behavior is used as a fallback.
> 
> ```ts
> import * as assert from 'node:assert/strict';
> import * as http from 'node:http';
> import { createRequestListener } from '@mjackson/node-fetch-server';
> 
> function handler(request: Request) {
>   // This is now true
>   assert.equal(
>     new URL(request.url).host,
>     request.headers.get('x-forwarded-host'),
>   );
>   return new Response('Hello, world!');
> }
> 
> let server = http.createServer(
>   createRequestListener(handler, {
>     host: (headers) => headers.get('x-forwarded-host'),
>     protocol: (headers) => (headers.get('x-forwarded-proto') ?? 'http') + ':',
>   }),
> );
> 
> server.listen(3000);
> ```
> 