### PR TITLE
Added async iterator with preflight to file-storage list operation

### DIFF
--- a/packages/file-storage/src/file-storage.ts
+++ b/packages/file-storage/src/file-storage.ts
@@ -5,3 +5,8 @@ export type {
   ListOptions,
   ListResult,
 } from './lib/file-storage.ts';
+
+export {
+  FileIterator,
+  FileStorageIterationError,
+} from './lib/file-iterator.ts';

--- a/packages/file-storage/src/lib/file-iterator.ts
+++ b/packages/file-storage/src/lib/file-iterator.ts
@@ -1,0 +1,167 @@
+import type {
+  FileKey,
+  FileMetadata,
+  FileStorage,
+  ListOptions,
+  ListResult,
+} from './file-storage.ts';
+
+/**
+ * Error thrown when there is a problem during file storage iteration.
+ */
+export class FileStorageIterationError extends Error {
+  cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'FileStorageIterationError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Options for iterating over files in storage.
+ */
+export interface IterateOptions<T extends ListOptions> extends ListOptions {
+    /**
+     * The number of items to fetch per page.
+     */
+    pageSize?: number;
+    /**
+     * Signal that can be used to abort the iteration.
+     */
+    signal?: AbortSignal;
+
+    /**
+     * The first page of files to yield. Allows starting iteration from a specific point.
+     */
+    firstPage?: (T extends { includeMetadata: true } ? FileMetadata : FileKey)[]
+}
+
+/**
+ * Internal helper class that implements the async iteration logic for FileStorage.
+ * 
+ * This class handles pagination and prefetching of files from storage, providing
+ * an efficient way to iterate over large datasets without loading everything into
+ * memory at once.
+ */
+export class FileIterator<T extends ListOptions> implements AsyncIterable<(T extends { includeMetadata: true } ? FileMetadata : FileKey)> {
+  private storage: FileStorage;
+  private options: IterateOptions<T>;
+  private pageSize: number;
+  private itemsYielded: number;
+  private limit: number | undefined;
+
+  constructor(storage: FileStorage, options?: IterateOptions<T>) {
+    this.storage = storage;
+    this.options = options ?? {} as T;
+    this.limit = options?.limit;
+    this.itemsYielded = 0;
+    this.pageSize = options?.pageSize ?? 32;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<(T extends { includeMetadata: true } ? FileMetadata : FileKey)> {
+    let nextPagePromise: Promise<ListResult<T>> | null = null;
+
+    // Helper function to fetch a page
+    const fetchPage = async (remainingItems: number | undefined, cursor?: string): Promise<ListResult<T>> => {
+      if(remainingItems === 0) {
+        return {
+          cursor: undefined,
+          files: [],
+          [Symbol.asyncIterator]() {
+            return {
+              next: async () => ({ done: true, value: undefined })
+            };
+          }
+        };
+      }
+
+      try {
+        // Adjust page size if needed based on remaining items
+        const adjustedPageSize = remainingItems && remainingItems < this.pageSize 
+          ? remainingItems 
+          : this.pageSize;
+
+        // One last check for abort status
+        if (this.options.signal?.aborted) {
+            return Promise.reject(new FileStorageIterationError('Iteration aborted', 
+                this.options.signal.reason
+            ));
+        }
+
+        const result = await this.storage.list({
+          ...this.options,
+          cursor,
+          limit: adjustedPageSize
+        } as T);
+        return result;
+      } catch (error) {
+        throw new FileStorageIterationError('Error fetching page from storage', 
+          error
+        );
+      }
+    };
+
+    try {
+      // If we have a first page, yield it and set up next page fetch
+      if (this.options.firstPage) {
+        // Check for abort before yielding first page
+        if (this.options.signal?.aborted) {
+          throw new FileStorageIterationError('Iteration aborted', 
+            this.options.signal.reason
+          );
+        }
+        const firstPage = this.limit && this.limit < this.options.firstPage.length 
+            ? this.options.firstPage.slice(0, this.limit)
+            : this.options.firstPage;
+        yield* firstPage;
+        this.itemsYielded += firstPage.length;
+        
+        nextPagePromise = this.options.cursor ? fetchPage(this.limit ? this.limit - this.itemsYielded : undefined, this.options.cursor) : null;
+      } else {
+        // Start fetching the first page
+        nextPagePromise = fetchPage(this.limit ? this.limit - this.itemsYielded : undefined);
+      }
+
+      while (nextPagePromise !== null) {
+        if (this.options.signal?.aborted) {
+            throw new FileStorageIterationError('Iteration aborted', 
+              this.options.signal.reason
+            );
+        }
+        
+        const remainingItems = this.limit ? this.limit - this.itemsYielded : undefined;
+        // Wait for the current page to load
+        const currentPage: ListResult<T> = await nextPagePromise;
+        
+        // If we have a next page, start fetching it in the background
+        nextPagePromise = currentPage.cursor ? fetchPage(remainingItems, currentPage.cursor) : null;
+
+        // If we got no files, we're done
+        if (currentPage.files.length === 0) {
+          break;
+        }
+
+        // Check for abort before yielding
+        if (this.options.signal?.aborted) {
+          throw new FileStorageIterationError('Iteration aborted', 
+            this.options.signal.reason
+          );
+        }
+
+        // Yield the current page (respecting the limit)
+        if (remainingItems && remainingItems < currentPage.files.length) {
+            currentPage.files = currentPage.files.slice(0, remainingItems);
+        }
+        yield* currentPage.files;
+        this.itemsYielded += currentPage.files.length;
+      }
+    } catch (error) {
+      if (error instanceof FileStorageIterationError) {
+        throw error;
+      }
+      throw new FileStorageIterationError('Error during iteration', error);
+    }
+  }
+} 

--- a/packages/file-storage/src/lib/local-file-storage.test.ts
+++ b/packages/file-storage/src/lib/local-file-storage.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { LocalFileStorage } from './local-file-storage.ts';
+import { FileStorageIterationError } from './file-iterator.ts';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
@@ -110,6 +111,84 @@ describe('LocalFileStorage', () => {
     files.forEach((f) => assert.ok('type' in f));
   });
 
+  it('supports async iteration over list results', async () => {
+    let storage = new LocalFileStorage(directory);
+    let allKeys = ['a', 'b', 'c', 'd', 'e'];
+
+    await Promise.all(
+      allKeys.map((key) =>
+        storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' })),
+      ),
+    );
+
+    let result = await storage.list();
+    let iteratedKeys = [];
+    
+    for await (const file of result) {
+      iteratedKeys.push(file.key);
+    }
+
+    assert.deepEqual(iteratedKeys.sort(), allKeys.sort());
+  });
+
+  it('respects limit during async iteration', async () => {
+    let storage = new LocalFileStorage(directory);
+    let allKeys = ['a', 'b', 'c', 'd', 'e'];
+
+    await Promise.all(
+      allKeys.map((key) =>
+        storage.set(key, new File([`Hello ${key}!`], `${key}.txt`, { type: 'text/plain' })),
+      ),
+    );
+
+    let result = await storage.list({ limit: 3 });
+    let iteratedKeys = [];
+    
+    for await (const file of result) {
+      iteratedKeys.push(file.key);
+    }
+
+    assert.equal(iteratedKeys.length, 3);
+    assert.ok(result.cursor !== undefined); // Should have a cursor for pagination
+    
+    // Get next page
+    let nextResult = await storage.list({ cursor: result.cursor });
+    let nextKeys = [];
+    for await (const file of nextResult) {
+      nextKeys.push(file.key);
+    }
+    
+    assert.equal(nextKeys.length, 2); // Should get remaining 2 items
+    assert.equal(nextResult.cursor, undefined); // No more pages
+  });
+
+  it('supports async iteration with metadata', async () => {
+    let storage = new LocalFileStorage(directory);
+    let allKeys = ['a', 'b', 'c'];
+    let lastModified = Date.now();
+
+    await Promise.all(
+      allKeys.map((key) =>
+        storage.set(key, new File([`Hello ${key}!`], `hello.txt`, {
+          type: 'text/plain',
+          lastModified
+        })),
+      ),
+    );
+
+    let result = await storage.list({ includeMetadata: true });
+    
+    for await (const file of result) {
+      assert.ok('lastModified' in file);
+      assert.ok('name' in file);
+      assert.ok('size' in file);
+      assert.ok('type' in file);
+      assert.equal(file.name, 'hello.txt');
+      assert.equal(file.type, 'text/plain');
+      assert.equal(file.lastModified, lastModified);
+    }
+  });
+
   it('handles race conditions', async () => {
     let storage = new LocalFileStorage(directory);
     let lastModified = Date.now();
@@ -135,5 +214,117 @@ describe('LocalFileStorage', () => {
     let retrieved2 = await storage.get('two');
     assert.ok(retrieved2);
     assert.equal(await retrieved2.text(), 'Hello, universe!');
+  });
+
+  describe('iterate', () => {
+    it('iterates over all files with default settings', async () => {
+      let storage = new LocalFileStorage(directory);
+      let allKeys = ['a', 'b', 'c', 'd', 'e'];
+
+      await Promise.all(
+        allKeys.map((key) =>
+          storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' })),
+        ),
+      );
+
+      let foundKeys = [];
+      for await (const file of storage.iterate()) {
+        foundKeys.push(file.key);
+      }
+
+      assert.deepEqual(foundKeys.sort(), allKeys.sort());
+    });
+
+    it('iterates with metadata', async () => {
+      let storage = new LocalFileStorage(directory);
+      let allKeys = ['a', 'b', 'c'];
+      let lastModified = Date.now();
+
+      await Promise.all(
+        allKeys.map((key) =>
+          storage.set(key, new File([`Hello ${key}!`], `hello.txt`, {
+            type: 'text/plain',
+            lastModified
+          })),
+        ),
+      );
+
+      for await (const file of storage.iterate({ includeMetadata: false })) {
+        assert.equal('lastModified' in file, false);
+        assert.equal('name' in file, false);
+        assert.equal('size' in file, false);
+        assert.equal('type' in file, false);
+      }
+
+      for await (const file of storage.iterate({ includeMetadata: true })) {
+        assert.ok('lastModified' in file);
+        assert.ok('name' in file);
+        assert.ok('size' in file);
+        assert.ok('type' in file);
+        assert.equal(file.type, 'text/plain');
+        assert.equal(file.name, 'hello.txt');
+        assert.equal(file.lastModified, lastModified);
+      }
+    });
+
+    it('iterates with prefix filter', async () => {
+      let storage = new LocalFileStorage(directory);
+      let allKeys = ['a/1', 'a/2', 'b/1', 'c/1'];
+
+      await Promise.all(
+        allKeys.map((key) =>
+          storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' })),
+        ),
+      );
+
+      let foundKeys = [];
+      for await (const file of storage.iterate({ prefix: 'a/' })) {
+        foundKeys.push(file.key);
+      }
+
+      assert.deepEqual(foundKeys.sort(), ['a/1', 'a/2']);
+    });
+
+    it('handles abort signal', async () => {
+      let storage = new LocalFileStorage(directory);
+      let allKeys = Array.from({ length: 10 }, (_, i) => `key${i}`);
+
+      for (const key of allKeys) {
+        await storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' }));
+      }
+
+      const controller = new AbortController();
+      const iterator = storage.iterate({
+        pageSize: 2,
+        signal: controller.signal
+      })[Symbol.asyncIterator]();
+
+      // Get first file
+      const firstFile = await iterator.next();
+      assert.ok(!firstFile.done);
+
+      // Abort the iteration
+      // Whether a second page gets fetched is ambiguous behavior, but a third page will not be fetched
+      controller.abort();
+
+      // Get second file - this should always work
+      const secondFile = await iterator.next();
+      assert.ok(!secondFile.done);
+
+      try {
+        // Get third file - this is deliberately ambiguous behavior
+        const thirdFile = await iterator.next();
+        assert.ok(!thirdFile.done);
+        // Get fourth file - this is deliberately ambiguous behavior
+        const fourthFile = await iterator.next();
+        assert.ok(!fourthFile.done);
+        // Get fifth file - this should always fail
+        await iterator.next();
+        assert.fail('Expected iteration to be aborted after at most 2 pages');
+      } catch (error) {
+        assert.ok(error instanceof FileStorageIterationError);
+        assert.equal(error.message, 'Iteration aborted');
+      }
+    });
   });
 });

--- a/packages/file-storage/src/lib/memory-file-storage.test.ts
+++ b/packages/file-storage/src/lib/memory-file-storage.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { MemoryFileStorage } from './memory-file-storage.ts';
+import { FileStorageIterationError } from './file-iterator.ts';
 
 describe('MemoryFileStorage', () => {
   it('stores and retrieves files', async () => {
@@ -96,5 +97,185 @@ describe('MemoryFileStorage', () => {
     files.forEach((f) => assert.ok('name' in f));
     files.forEach((f) => assert.ok('size' in f));
     files.forEach((f) => assert.ok('type' in f));
+  });
+
+  it('supports async iteration over list results', async () => {
+    let storage = new MemoryFileStorage();
+    let allKeys = ['a', 'b', 'c', 'd', 'e'];
+
+    await Promise.all(
+      allKeys.map((key) =>
+        storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' })),
+      ),
+    );
+
+    let result = storage.list();
+    let iteratedKeys = [];
+    
+    for await (const file of result) {
+      iteratedKeys.push(file.key);
+    }
+
+    assert.deepEqual(iteratedKeys.sort(), allKeys.sort());
+  });
+
+  it('respects limit during async iteration', async () => {
+    let storage = new MemoryFileStorage();
+    let allKeys = ['a', 'b', 'c', 'd', 'e'];
+
+    await Promise.all(
+      allKeys.map((key) =>
+        storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' })),
+      ),
+    );
+
+    let result = storage.list({ limit: 3 });
+    let iteratedKeys = [];
+    
+    for await (const file of result) {
+      iteratedKeys.push(file.key);
+    }
+  });
+
+  it('supports async iteration with metadata', async () => {
+    let storage = new MemoryFileStorage();
+    let allKeys = ['a', 'b', 'c'];
+    let lastModified = Date.now();
+
+    await Promise.all(
+      allKeys.map((key) =>
+        storage.set(key, new File([`Hello ${key}!`], `hello.txt`, {
+          type: 'text/plain',
+          lastModified
+        })),
+      ),
+    );
+
+    let result = storage.list({ includeMetadata: true });
+    
+    for await (const file of result) {
+      assert.ok('lastModified' in file);
+      assert.ok('name' in file);
+      assert.ok('size' in file);
+      assert.ok('type' in file);
+      assert.equal(file.lastModified, lastModified);
+      assert.equal(file.name, 'hello.txt');
+      assert.equal(file.type, 'text/plain');
+    }
+  });
+
+  describe('iterate', () => {
+    it('iterates over all files with default settings', async () => {
+      let storage = new MemoryFileStorage();
+      let allKeys = ['a', 'b', 'c', 'd', 'e'];
+
+      await Promise.all(
+        allKeys.map((key) =>
+          storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' })),
+        ),
+      );
+
+      let foundKeys = [];
+      for await (const file of storage.iterate()) {
+        foundKeys.push(file.key);
+      }
+
+      assert.deepEqual(foundKeys.sort(), allKeys.sort());
+    });
+
+    it('iterates with metadata', async () => {
+      let storage = new MemoryFileStorage();
+      let allKeys = ['a', 'b', 'c'];
+      let lastModified = Date.now();
+
+      await Promise.all(
+        allKeys.map((key) =>
+          storage.set(key, new File([`Hello ${key}!`], `hello.txt`, {
+            type: 'text/plain',
+            lastModified
+          })),
+        ),
+      );
+
+      for await (const file of storage.iterate({ includeMetadata: false })) {
+        assert.equal('lastModified' in file, false);
+        assert.equal('name' in file, false);
+        assert.equal('size' in file, false);
+        assert.equal('type' in file, false);
+      }
+
+      for await (const file of storage.iterate({ includeMetadata: true })) {
+        assert.ok('lastModified' in file);
+        assert.ok('name' in file);
+        assert.ok('size' in file);
+        assert.ok('type' in file);
+        assert.equal(file.type, 'text/plain');
+        assert.equal(file.name, 'hello.txt');
+        assert.equal(file.lastModified, lastModified);
+      }
+    });
+
+    it('iterates with prefix filter', async () => {
+      let storage = new MemoryFileStorage();
+      let allKeys = ['a/1', 'a/2', 'b/1', 'c/1'];
+
+      await Promise.all(
+        allKeys.map((key) =>
+          storage.set(key, new File([`Hello ${key}!`], `hello.txt`, { type: 'text/plain' })),
+        ),
+      );
+
+      let foundKeys = [];
+      for await (const file of storage.iterate({ prefix: 'a/' })) {
+        foundKeys.push(file.key);
+      }
+
+      assert.deepEqual(foundKeys.sort(), ['a/1', 'a/2']);
+    });
+
+    it('handles abort signal', async () => {
+      let storage = new MemoryFileStorage();
+      let allKeys = Array.from({ length: 10 }, (_, i) => `key${i}`);
+
+      await Promise.all(
+        allKeys.map((key) =>
+          storage.set(key, new File([`Hello ${key}!`], `${key}.txt`, { type: 'text/plain' }))
+        )
+      );
+
+      const controller = new AbortController();
+      const iterator = storage.iterate({
+        pageSize: 2,
+        signal: controller.signal
+      })[Symbol.asyncIterator]();
+
+      // Get first file
+      const firstFile = await iterator.next();
+      assert.ok(!firstFile.done);
+
+      // Abort
+      // Whether a second page gets fetched is ambiguous behavior, but a third page will not be fetched
+      controller.abort();
+
+      // Get second file - this should always work
+      const secondFile = await iterator.next();
+      assert.ok(!secondFile.done);
+
+      try {
+        // Get third file - whether this throws or not is deliberately ambiguous behavior because these results could already be in memory
+        const thirdFile = await iterator.next();
+        assert.ok(!thirdFile.done);
+        // Get fourth file - whether this throws or not is deliberately ambiguous behavior because these results could already be in memory
+        const fourthFile = await iterator.next();
+        assert.ok(!fourthFile.done);
+
+        // Get fifth file - this should always fail
+        await iterator.next();
+        assert.fail('Expected iteration to be aborted');
+      } catch (error) {
+        assert.ok(error instanceof FileStorageIterationError);
+        assert.equal(error.message, 'Iteration aborted');
+      }
+    });
   });
 });


### PR DESCRIPTION
This adds async iteration to the file-system list operations.

I got a little carried away and proposed adding directly to the list() response, this might be too opinionated though, let me know what you think, it could be just the separate iterate() method.

A good summary of the changes is in the CHANGELOG diff.