### PR TITLE
fix: make headers HTTPs compatible

### DIFF
--- a/packages/node-fetch-server/src/lib/request-listener.ts
+++ b/packages/node-fetch-server/src/lib/request-listener.ts
@@ -172,6 +172,7 @@ export function createHeaders(req: http.IncomingMessage): Headers {
 
   let rawHeaders = req.rawHeaders;
   for (let i = 0; i < rawHeaders.length; i += 2) {
+    if (rawHeaders[i].startsWith(":")) continue;
     headers.append(rawHeaders[i], rawHeaders[i + 1]);
   }
 


### PR DESCRIPTION
When using https headers such as `:method` exist, and these are "invalid" headers in the Fetch spec causing errors to be thrown during Request construction.