### PR TITLE
chore: add formidable v3 to benchmarks

### DIFF
--- a/packages/multipart-parser/bench/package.json
+++ b/packages/multipart-parser/bench/package.json
@@ -6,7 +6,8 @@
     "@fastify/busboy": "^3.0.0",
     "@mjackson/multipart-parser": "workspace:*",
     "busboy": "^1.6.0",
-    "multipasta": "^0.2.4"
+    "multipasta": "^0.2.4",
+    "formidable": "^3.5.4"
   },
   "devDependencies": {
     "@types/bun": "^1.1.6",

--- a/packages/multipart-parser/bench/parsers/formidable-v3.ts
+++ b/packages/multipart-parser/bench/parsers/formidable-v3.ts
@@ -1,0 +1,144 @@
+import { MultipartParser, defaultOptions } from 'formidable';
+import { Stream } from 'node:stream';
+import { MultipartMessage } from '../messages.ts';
+
+export async function parse(input: MultipartMessage): Promise<number> {
+  let start = performance.now();
+
+  const parser = formidableMultipart(input.boundary, {
+    onPart(part: any) {
+      // console.log(part);
+    },
+  });
+
+  for await (const chunk of input.generateChunks()) {
+    parser.write(chunk);
+  }
+
+  parser.end();
+
+  return performance.now() - start;
+}
+
+function formidableMultipart(boundary: string, options = defaultOptions) {
+  const parser = new MultipartParser(options);
+  let headerField = '';
+  let headerValue = '';
+  let part: any;
+
+  parser.initWithBoundary(boundary);
+
+  // eslint-disable-next-line max-statements, consistent-return
+  parser.on('data', async ({ name, buffer, start, end }: any) => {
+    if (name === 'partBegin') {
+      part = new Stream();
+      part.readable = true;
+      part.headers = {};
+      part.name = null;
+      part.originalFilename = crypto.randomUUID();
+      part.mimetype = null;
+
+      part.transferEncoding = options.encoding;
+      part.transferBuffer = '';
+
+      headerField = '';
+      headerValue = '';
+    } else if (name === 'headerField') {
+      headerField += buffer.toString(options.encoding, start, end);
+    } else if (name === 'headerValue') {
+      headerValue += buffer.toString(options.encoding, start, end);
+    } else if (name === 'headerEnd') {
+      headerField = headerField.toLowerCase();
+      part.headers[headerField] = headerValue;
+
+      // matches either a quoted-string or a token (RFC 2616 section 19.5.1)
+      const m = headerValue.match(
+        // eslint-disable-next-line no-useless-escape
+        /\bname=("([^"]*)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))/i,
+      );
+      if (headerField === 'content-disposition') {
+        if (m) {
+          part.name = m[2] || m[3] || '';
+        }
+
+        // matches either a quoted-string or a token (RFC 2616 section 19.5.1)
+        const m2 = headerValue.match(
+          // eslint-disable-next-line no-useless-escape
+          /\bfilename=("([^"]*)"|([^\(\)<>@,;:\\"\/\[\]\?=\{\}\s\t/]+))/i,
+        );
+        if (m2) {
+          part.originalFilename = m2[2] || m2[3] || crypto.randomUUID();
+        }
+      } else if (headerField === 'content-type') {
+        part.mimetype = headerValue;
+      } else if (headerField === 'content-transfer-encoding') {
+        part.transferEncoding = headerValue.toLowerCase();
+      }
+
+      headerField = '';
+      headerValue = '';
+    } else if (name === 'headersEnd') {
+      switch (part.transferEncoding) {
+        case 'binary':
+        case '7bit':
+        case '8bit':
+        case 'utf-8': {
+          const dataPropagation = (ctx: any) => {
+            if (ctx.name === 'partData') {
+              part.emit('data', ctx.buffer.slice(ctx.start, ctx.end));
+            }
+          };
+          const dataStopPropagation = (ctx: any) => {
+            if (ctx.name === 'partEnd') {
+              part.emit('end');
+              parser.off('data', dataPropagation);
+              parser.off('data', dataStopPropagation);
+            }
+          };
+          parser.on('data', dataPropagation);
+          parser.on('data', dataStopPropagation);
+          break;
+        }
+        case 'base64': {
+          const dataPropagation = (ctx: any) => {
+            if (ctx.name === 'partData') {
+              part.transferBuffer += ctx.buffer.slice(ctx.start, ctx.end).toString('ascii');
+
+              /*
+                  four bytes (chars) in base64 converts to three bytes in binary
+                  encoding. So we should always work with a number of bytes that
+                  can be divided by 4, it will result in a number of bytes that
+                  can be divided by 3.
+                  */
+              const buflen = part.transferBuffer.length;
+
+              const offset = Number.parseInt(String(buflen / 4), 10) * 4;
+              part.emit('data', Buffer.from(part.transferBuffer.substring(0, offset), 'base64'));
+              part.transferBuffer = part.transferBuffer.substring(offset);
+            }
+          };
+          const dataStopPropagation = (ctx: any) => {
+            if (ctx.name === 'partEnd') {
+              part.emit('data', Buffer.from(part.transferBuffer, 'base64'));
+              part.emit('end');
+              parser.off('data', dataPropagation);
+              parser.off('data', dataStopPropagation);
+            }
+          };
+          parser.on('data', dataPropagation);
+          parser.on('data', dataStopPropagation);
+          break;
+        }
+        // default:
+        //   console.error('unknown transfer-encoding');
+      }
+      parser.pause();
+      await options?.onPart(part);
+      parser.resume();
+    } else if (name === 'end') {
+      parser.emit('end');
+    }
+  });
+
+  return parser;
+}

--- a/packages/multipart-parser/bench/runner.ts
+++ b/packages/multipart-parser/bench/runner.ts
@@ -4,6 +4,7 @@ import * as process from 'node:process';
 import * as messages from './messages.ts';
 import * as busboy from './parsers/busboy.ts';
 import * as fastifyBusboy from './parsers/fastify-busboy.ts';
+import * as formidableV3 from './parsers/formidable-v3.ts';
 import * as multipartParser from './parsers/multipart-parser.ts';
 import * as multipasta from './parsers/multipasta.ts';
 
@@ -57,6 +58,9 @@ async function runBenchmarks(parserName?: string): Promise<BenchmarkResults> {
   }
   if (parserName === 'multipasta' || parserName === undefined) {
     results['multipasta'] = await runParserBenchmarks(multipasta);
+  }
+  if (parserName === 'formidable-v3' || parserName === undefined) {
+    results['formidable-v3'] = await runParserBenchmarks(formidableV3);
   }
   if (parserName === 'busboy' || parserName === undefined) {
     results.busboy = await runParserBenchmarks(busboy);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       busboy:
         specifier: ^1.6.0
         version: 1.6.0
+      formidable:
+        specifier: ^3.5.4
+        version: 3.5.4
       multipasta:
         specifier: ^0.2.4
         version: 0.2.5
@@ -658,6 +661,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@octokit/endpoint@10.1.1':
     resolution: {integrity: sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==}
     engines: {node: '>= 18'}
@@ -675,6 +682,9 @@ packages:
 
   '@octokit/types@13.6.2':
     resolution: {integrity: sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==}
+
+  '@paralleldrive/cuid2@2.2.2':
+    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -962,6 +972,9 @@ packages:
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
@@ -1127,6 +1140,9 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+
   duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
 
@@ -1211,6 +1227,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2117,6 +2137,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@noble/hashes@1.8.0': {}
+
   '@octokit/endpoint@10.1.1':
     dependencies:
       '@octokit/types': 13.6.2
@@ -2138,6 +2160,10 @@ snapshots:
   '@octokit/types@13.6.2':
     dependencies:
       '@octokit/openapi-types': 22.2.0
+
+  '@paralleldrive/cuid2@2.2.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2384,6 +2410,8 @@ snapshots:
     dependencies:
       printable-characters: 1.0.42
 
+  asap@2.0.6: {}
+
   b4a@1.6.7: {}
 
   balanced-match@1.0.2: {}
@@ -2537,6 +2565,11 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
+
   duplexify@3.7.1:
     dependencies:
       end-of-stream: 1.4.4
@@ -2688,6 +2721,12 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.5
       signal-exit: 4.1.0
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.2.2
+      dezalgo: 1.0.4
+      once: 1.4.0
 
   forwarded@0.2.0: {}
 


### PR DESCRIPTION
added Formidable v3 to the bench suite.

It wraps the `MultipartParser` directly, because the API is bad enough, haha. I'm actually sick of looking at this `Formidable` class.. :man_shrugging: 

Please run it on your machine, because in my machine today it seems that all are having hard time running and seems like the Formidable v3 is fastest, it shouldn't be. And no, it's not something like `formidable` failing that's why it's fast, i tried the custom `formidableMultipart` wrapper i extracted from the Formidable. Weird.. don't know.

That's why i'm submitting the PR to check where we are now.