### PR TITLE
fetch-proxy: remove content-* headers and apply init params to proxied request

### DIFF
--- a/packages/fetch-proxy/CHANGELOG.md
+++ b/packages/fetch-proxy/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is the changelog for [`fetch-proxy`](https://github.com/mjackson/remix-the-web/tree/main/packages/fetch-proxy). It follows [semantic versioning](https://semver.org/).
 
+## HEAD
+
+- Remove 'Content-Encoding' and 'Content-Length' headers from proxied response.
+- Apply all RequestInit params to the proxied request.
+
 ## v0.2.0 (2024-11-14)
 
 - Added CommonJS build

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -145,4 +145,24 @@ describe('fetch proxy', () => {
     assert.equal(setCookie[0], 'name=value; Domain=remix.run:3000; Path=/rsc/search');
     assert.equal(setCookie[1], 'name2=value2; Domain=remix.run:3000; Path=/rsc');
   });
+
+  it('deletes content-encoding and content-length headers', async () => {
+    let { response } = await runProxy(
+      new Request('http://shopify.com/search?q=remix'),
+      'https://remix.run:3000/rsc',
+      {
+        async fetch() {
+          return new Response(null, {
+            headers: [
+              ['Content-Encoding', 'gzip'],
+              ['Content-Length', '1337'],
+            ],
+          });
+        },
+      },
+    );
+
+    assert.equal(response.headers.has('Content-Encoding'), false);
+    assert.equal(response.headers.has('Content-Length'), false);
+  });
 });

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -104,6 +104,9 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
       }
     }
 
+    responseHeaders.delete('Content-Encoding');
+    responseHeaders.delete('Content-Length');
+
     return new Response(targetResponse.body, {
       status: targetResponse.status,
       statusText: targetResponse.statusText,

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -66,6 +66,7 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
     let proxyInit: RequestInit = {
       method: incomingRequest.method,
       headers: proxyHeaders,
+      ...init,
     };
     if (incomingRequest.method !== 'GET' && incomingRequest.method !== 'HEAD') {
       proxyInit.body = incomingRequest.body;


### PR DESCRIPTION
Hi :wave:,

As mentioned in #38, after starting to use this library I've had to make some hacky workarounds to a few things to get the proxy to behave how I'd like, including:

* Deleting the 'Content-Type' and 'Content-Length' headers to avoid errors when `fetch` automatically modifies the content of the response.
* Set the `redirect` mode on the request to handle a proxied request returning a redirect and the proxy not being able to handle it.